### PR TITLE
Enable python_socket test.

### DIFF
--- a/rosserial_test/CMakeLists.txt
+++ b/rosserial_test/CMakeLists.txt
@@ -44,7 +44,7 @@ if(CATKIN_ENABLE_TESTING)
 
   add_rostest(test/rosserial_server_socket.test)
   add_rostest(test/rosserial_server_serial.test)
-  # add_rostest(test/rosserial_python_socket.test)
+  add_rostest(test/rosserial_python_socket.test)
   # Disabled due to reconnect logic in rosserial_python not being robust enough.
   # add_rostest(test/rosserial_python_serial.test)
 endif()


### PR DESCRIPTION
Tiny update to https://github.com/ros-drivers/rosserial/pull/508